### PR TITLE
Form data posting

### DIFF
--- a/src/OAuth/Consumer.js
+++ b/src/OAuth/Consumer.js
@@ -72,7 +72,7 @@
             this.request = function (options) {
                 var method, url, data, headers, success, failure, xhr, i,
                     headerParams, signatureMethod, signatureString, signature,
-                    query = [], appendQueryString, signatureData = {}, params;
+                    query = [], appendQueryString, signatureData = {}, params, withFile;
 
                 method = options.method || 'GET';
                 url = URI(options.url);
@@ -80,6 +80,19 @@
                 headers = options.headers || {};
                 success = options.success || function (data) {};
                 failure = options.failure || function () {};
+
+                // According to the spec
+                withFile = (function(){
+                  var hasFile = false;
+                  for(var name in data) {
+                    // Thanks tho the FileAPI any file entry
+                    // has a fileName property
+                    if(typeof data[name].fileName != 'undefined') hasFile = true;
+                  }
+
+                  return hasFile;
+                })();
+
                 appendQueryString = options.appendQueryString ? options.appendQueryString : false;
 
                 if (oauth.enablePrivilege) {
@@ -138,11 +151,18 @@
                 	signatureData[i] = params[i];
                 }
 
-                for (i in data) {
-                	signatureData[i] = data[i];
+                // According to the OAuth spec
+                // if data is transfered using
+                // multipart the POST data doesn't
+                // have to be signed:
+                // http://www.mail-archive.com/oauth@googlegroups.com/msg01556.html
+                if(!withFile) {
+                  for (i in data) {
+                    signatureData[i] = data[i];
+                  }
                 }
 
-				urlString = url.scheme + '://' + url.host + url.path;
+                urlString = url.scheme + '://' + url.host + url.path;
                 signatureString = toSignatureBaseString(method, urlString, headerParams, signatureData);
                 signature = OAuth.signatureMethod[signatureMethod](oauth.consumerSecret, oauth.accessTokenSecret, signatureString);
 
@@ -151,12 +171,20 @@
                 if(appendQueryString || method == 'GET') {
 	                url.query.setQueryParams(data);
                     query = null;
-                } else {
+                } else if(! withFile){
                 	for(i in data) {
-                	    query.push(OAuth.urlEncode(i) + '=' + OAuth.urlEncode(data[i] + ''));
+                    query.push(OAuth.urlEncode(i) + '=' + OAuth.urlEncode(data[i] + ''));
                 	}
                 	query = query.sort().join('&');
                     headers['Content-Type'] = 'application/x-www-form-urlencoded';
+                } else if(withFile) {
+                  // When using FormData multipart content type
+                  // is used by default and required header
+                  // is set to multipart/form-data etc
+                  query = new FormData();
+                  for(i in data) {
+                    query.append(i, data[i]);
+                  }
                 }
 
                 xhr.open(method, url+'', true);
@@ -220,7 +248,7 @@
 
         	return obj;
         },
-        
+
         fetchRequestToken: function (success, failure) {
         	var url = this.authorizationUrl;
         	var oauth = this;
@@ -230,13 +258,13 @@
         		success(url + '?' + data.text);
         	}, failure);
         },
-        
+
         fetchAccessToken: function (success, failure) {
         	var oauth = this;
         	this.get(this.accessTokenUrl, function (data) {
         		var token = oauth.parseTokenRequest(data.text);
         		oauth.setAccessToken([token.oauth_token, token.oauth_token_secret]);
-        		
+
         		success(data);
         	}, failure);
         }


### PR DESCRIPTION
This patch adds the ability to post files via OAuth, unfortunately it requires FormData, but from what I can see it's available in pretty much any modern browser, namely those which can be used for building rich apps.

It's completely transparent, so that the old code works as well, i.e:

Given that oauth is an working OAuth object and can make requests this will work like the old code

```
oath.post('some.url.com', { status : "hi!"}, callbacks.onSuccess, callbacks.onFailure);
```

Now this will change the internal behaviour:

```
var file = document.querySelector('input[type="file"]').files[0];
oauth.post('some.url.com/file_upload', { status : 'hi', attachment : file, } callbacks.onSuccess, callbacks.onFailure);
```

and post all data without signing it.

My initial version had two methods :`post` (the old one) and `postWithFile` but I figured that it doesn't make sense to create more branches in the code.

I've tested this against Blip.pl API, I'm pretty sure it works with Twitpic, but I haven't tried that yet.
