### PR TITLE
Typo in line 143 - spotted by JS Lint.

### DIFF
--- a/src/OAuth/URI.js
+++ b/src/OAuth/URI.js
@@ -140,7 +140,7 @@
                 }
             }
         } else {
-            for (i = 0; i < arg_length; i += 2) {
+            for (i = 0; i < args_length; i += 2) {
                 // treat each arg as key, then value
                 querystring[args[i]] = args[i+1];
             }


### PR DESCRIPTION
JS Lint reports arg_length not defined, assume you meant args_length.

v1.3.3 much improved on v1.3.1 thanks for all your effort on this.
