### PR TITLE
Additional option for using a proxy URL

### DIFF
--- a/src/OAuth/Consumer.js
+++ b/src/OAuth/Consumer.js
@@ -25,6 +25,7 @@
             var oauth = {
                 enablePrivilege: options.enablePrivilege || false,
 
+                proxyUrl: options.proxyUrl,
                 callbackUrl: options.callbackUrl || 'oob',
 
                 consumerKey: options.consumerKey,
@@ -196,6 +197,10 @@
                 if (this.realm)
                 {
                     headerParams['realm'] = this.realm;
+                }
+                
+                if (oauth.proxyUrl) {
+                    url = URI(oauth.proxyUrl + url.path);                   
                 }
 
                 if(appendQueryString || method == 'GET') {


### PR DESCRIPTION
If you have setup http://foo.org/bar as proxy for http://bar.org then you can serve a script
file from foo.org and issue an oauth request to bar.org like this:

var oauth = OAuth({
   proxyUrl: 'http://foo.org/bar',
   consumerKey: '...',
   consumerSecret: '...'
});

oauth.get('http://bar.org/oauth/request_token', function() { /\* ... */ });

Also works with https URLs. (But remember to enable SSLProxyEngine if you are using Apache!)
