### PR TITLE
Change global in btoa segment to refer to exports instead of this

### DIFF
--- a/src/OAuth/Base64.js
+++ b/src/OAuth/Base64.js
@@ -34,4 +34,4 @@
 
         return output;
     };
-})(this);
+})(exports);


### PR DESCRIPTION
 for consistency (and also so it works on Titanium android)
