### PR TITLE
adding missing `var` declaration for `urlString`

### DIFF
--- a/src/OAuth/Consumer.js
+++ b/src/OAuth/Consumer.js
@@ -90,7 +90,7 @@
             this.request = function (options) {
                 var method, url, data, headers, success, failure, xhr, i,
                     headerParams, signatureMethod, signatureString, signature,
-                    query = [], appendQueryString, signatureData = {}, params, withFile;
+                    query = [], appendQueryString, signatureData = {}, params, withFile, urlString;
 
                 method = options.method || 'GET';
                 url = URI(options.url);


### PR DESCRIPTION
this was causing mocha tests to crash and burn with `global leak detected on urlString`.
