### PR TITLE
Are spaces allowed after delimiter?

### DIFF
--- a/src/OAuth/Consumer.js
+++ b/src/OAuth/Consumer.js
@@ -1,4 +1,3 @@
-
     /** @const */ var OAUTH_VERSION_1_0 = '1.0';
 
     /**
@@ -402,7 +401,7 @@
             arr.unshift(realm);
         }
 
-        return arr.join(', ');
+        return arr.join(',');
     }
 
     /**


### PR DESCRIPTION
I'm not sure what the spec says about this but service I'm hitting fails with the space and passes without it.  Which way is correct?  Or should both work?
